### PR TITLE
Use an external directory for storing logs of PostgreSQL

### DIFF
--- a/acid/senza/templates/base.py
+++ b/acid/senza/templates/base.py
@@ -102,7 +102,7 @@ SenzaComponents:
                   parameters:
                     logging_collector: on
                     log_destination: csvlog
-                    log_directory: pg_log
+                    log_directory: ../pg_log
                     log_filename: postgresql-%w.log
                     log_file_mode: 0644
                     log_rotation_age: 1d


### PR DESCRIPTION
Some Spilo's currently log to the filesystem inside docker. If these
files are stored inside $PGDATA, they are also part of any basebackup or WAL-E backup.
When these files grow big, WAL-E fails to backup, because it assumes no files inside $PGDATA
are bigger than 1.5GB.

There now is a pull request to address this at the WAL-E level: https://github.com/wal-e/wal-e/pull/278
however, it seems usefull to allow logs to persist outside the $PGDATA directory.

Ties in with https://github.com/zalando/spilo/pull/91